### PR TITLE
fix: Fix actualpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "actualpy~=0.10",
+    "actualpy==0.10.0",
     "jsonschema~=4.0",
     "pre-commit~=4.0",
     "pydantic~=2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -729,7 +729,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "actualpy", specifier = "~=0.10" },
+    { name = "actualpy", specifier = "==0.10.0" },
     { name = "jsonschema", specifier = "~=4.0" },
     { name = "pre-commit", specifier = "~=4.0" },
     { name = "pydantic", specifier = "~=2.0" },


### PR DESCRIPTION
This PR fixes the `actualpy` version to `0.10.0` as `0.11.0` is only supports Actual Server `2025.3.0`.