### PR TITLE
fix: Add already reconciled transactions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "actualpy==0.10.0",
+    "actualpy==0.11.0",
     "jsonschema~=4.0",
     "pre-commit~=4.0",
     "pydantic~=2.0",

--- a/up/app.py
+++ b/up/app.py
@@ -8,7 +8,7 @@ from up.transactions import get_account_transaction_urls, get_transactions_batch
 logger.info("Starting up...")
 
 up_api = UpAPI()
-query_params = QueryParams(start_date=datetime.datetime(2025, 3, 1), days_offset=0, page_size=100)
+query_params = QueryParams(start_date=datetime.datetime(2025, 2, 1), days_offset=0, page_size=100)
 actual_settings = Settings()  # type: ignore
 
 actual_init = ActualSession(

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "actualpy"
-version = "0.10.0"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
@@ -16,9 +16,9 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "sqlmodel" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/79/2f8e458922381400c5ff2cad8348a730596b842a85b429d91814a45a2f3a/actualpy-0.10.0.tar.gz", hash = "sha256:9c1e3c7ee6825d976906526356d05086cc5b8a3ab8cb67c3e037978a53bbdd46", size = 73920 }
+sdist = { url = "https://files.pythonhosted.org/packages/da/7c/2e42ac3421b06653b133abafba5420093338d76fdf95e1d93d7101247830/actualpy-0.11.0.tar.gz", hash = "sha256:343ef33684319492658e9a2a4180edc639748dd3622a1496acc46f7fe1b5fa40", size = 75545 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/77/37a40c755f6130ff91f3b9ff39f66eafcf38ddeb2cd0aa936d192a14456c/actualpy-0.10.0-py3-none-any.whl", hash = "sha256:d60007e42b891905a1581a86e387fef10cc721b49543dc4cd09f816f3d9511b9", size = 61509 },
+    { url = "https://files.pythonhosted.org/packages/da/40/02a9b0fba1ff518127819d664494a325cdca46e7c964e12a1283659dd2ae/actualpy-0.11.0-py3-none-any.whl", hash = "sha256:02e943648e5c08fe59eaccf958b29872c7cc3128b7df226808f7750dec15a0f2", size = 62383 },
 ]
 
 [[package]]
@@ -729,7 +729,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "actualpy", specifier = "==0.10.0" },
+    { name = "actualpy", specifier = "==0.11.0" },
     { name = "jsonschema", specifier = "~=4.0" },
     { name = "pre-commit", specifier = "~=4.0" },
     { name = "pydantic", specifier = "~=2.0" },


### PR DESCRIPTION
This PR adds already reconciled transactions so we can avoid overwriting already inserted transactions as well as to avoid duplicated when the app runs the same date ranges. 